### PR TITLE
Fix BASE_URL formatting for different inputs

### DIFF
--- a/scout/main.py
+++ b/scout/main.py
@@ -22,7 +22,7 @@ TOKEN = os.getenv("SCOUT_TOKEN")
 HEADERS = {'Authorization': 'token ' + TOKEN}
 
 # BASE_URL = "https://api.github.com/search/repositories?q=stars:%3E={}%20language:{}%20topic:hacktoberfest"
-BASE_URL = "https://api.github.com/search/repositories?q={}stars:%3C=1000%20language:python%20topic:hacktoberfest"
+BASE_URL = "https://api.github.com/search/repositories?q={}stars:%3C={}%20language:{}%20topic:hacktoberfest"
 
 
 def print_welcome_message() -> None:
@@ -40,7 +40,7 @@ def get_url():
     if standard.lower() in ("y", "yes", ""):
         max_stars = 1000
     else:
-        max_stars = int(console.input("[blue]Star count  range \[5-1000 is ideal]: "))
+        max_stars = int(console.input("[blue]Star count range \[5-1000 is ideal]: "))
     lang = console.input("Project language: \[python] ")
     if lang == "":
         lang = "python"


### PR DESCRIPTION
There was only one `{}` in the `BASE_URL`, so you would always get repos with <= 1000 stars in python. I added two `{}` so the `BASE_URL` changes if you input different max stars and language.

**Before**
<img width="616" alt="Screen Shot 2022-10-07 at 11 04 52 PM" src="https://user-images.githubusercontent.com/46979193/194685562-ae591dae-b78a-46d9-a320-ba09c51b686b.png">

**After**
<img width="1133" alt="Screen Shot 2022-10-07 at 11 11 35 PM" src="https://user-images.githubusercontent.com/46979193/194685572-50fc9b02-5e91-4497-890a-f01b8987c1de.png">

