### PR TITLE
Making README pypi friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Before running `scout`:
 4. Now you're good to go! Run `scout` to start!
    1. On windows, press <kbd>win</kbd> + <kbd>r</kbd>, type in `scout`, and click Ok.
 
-![Example](screenshot/standard_output.png)
+![Example](https://github.com/TechWiz-3/scout/raw/c84a9f0e601c1db1369aadeff0c9b920c7de9085/screenshot/standard_output.png)
 
 ## Show Forks Option
 ```bash
 scout --forks
 ```
-![Example](screenshot/show_forks_option.png)
+![Example](https://github.com/TechWiz-3/scout/raw/c84a9f0e601c1db1369aadeff0c9b920c7de9085/screenshot/show_forks_option.png)
 
 ## Contributors ❤️
 <br>

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ setup(
     author="Zac the Wise aka TechWiz-3",
     version='0.3.3',
     description="⭐ Find hacktoberfest repos to contribute to from your CLI",
-#    long_description_content_type='text/markdown',
-#    long_description=long_description,
+    long_description_content_type='text/markdown',
+    long_description=read_file("README.md"),
     packages=find_packages(),
     entry_points='''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 from setuptools import setup, find_packages
-#from pathlib import Path
+from pathlib import Path
 
 #project_dir = Path(__file__).parent
 #long_description = (project_dir / "README.md").read_text()
+
+
+
+def read_file(rel_path: str):
+    return Path(__file__).parent.joinpath(rel_path).read_text()
+
 
 setup(
     name="gh-scout",


### PR DESCRIPTION
This PR fixes #27 

 Summary of changes:
1)  Added a read_file function in `setup.py` to add README to `long_description`.
2)  Edited the links for screenshots to make the example images renderable by pypi.